### PR TITLE
Tornando a página de perfil dinâmica && Criando o relacionamento entre tabelas

### DIFF
--- a/clincode/src/main/java/com/api/clincode/controller/AtendenteController.java
+++ b/clincode/src/main/java/com/api/clincode/controller/AtendenteController.java
@@ -93,7 +93,11 @@ public class AtendenteController {
 
         //Adicionar essa lista de consultas (caso tenha) ao ModelAndView para ser exibido dinamicamente
 
+        ModelAndView mv = new ModelAndView("atendente-perfil");
+        mv.addObject("atendente", service.getAtendenteByID(id));
+        return mv;
+
         //Exibir a tela com as CONSULTAS REALIZADAS
-        return new ModelAndView("atendente-perfil");
+        // return new ModelAndView("atendente-perfil");
     } 
 }

--- a/clincode/src/main/java/com/api/clincode/controller/MedicoController.java
+++ b/clincode/src/main/java/com/api/clincode/controller/MedicoController.java
@@ -91,8 +91,13 @@ public class MedicoController {
 
         //Adicionar esse objeto no ModelAndView
 
-        //Exibir a tela de perfil        
-        return new ModelAndView("medico-perfil");
+        //Exibir a tela de perfil
+        
+        ModelAndView mv = new ModelAndView("medico-perfil");
+        mv.addObject("medico", service.getMedicoByID(id));
+        return mv;
+        
+        // return new ModelAndView("medico-perfil");
     }
 
 }

--- a/clincode/src/main/java/com/api/clincode/controller/MyErrorController.java
+++ b/clincode/src/main/java/com/api/clincode/controller/MyErrorController.java
@@ -1,0 +1,35 @@
+package com.api.clincode.controller;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class MyErrorController implements ErrorController {
+    
+    @RequestMapping("/error")
+    public String handleError(HttpServletRequest request) {
+        Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        
+        if (status != null) {
+            Integer statusCode = Integer.valueOf(status.toString());
+        
+            if(statusCode == HttpStatus.NOT_FOUND.value()) {
+                return "error-404";
+            }
+            else if(statusCode == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+                return "error-500";
+            }
+        }
+        return "error";
+    }
+    @Override
+    public String getErrorPath() {
+        return null;
+    }
+
+}

--- a/clincode/src/main/java/com/api/clincode/controller/PacienteController.java
+++ b/clincode/src/main/java/com/api/clincode/controller/PacienteController.java
@@ -80,14 +80,18 @@ public class PacienteController {
 
     //Pagina de perfil de cada paciente
     @GetMapping("{id}/perfil")
-    public ModelAndView medicoPerfil(@PathVariable final int id){
+    public ModelAndView pacientePerfil(@PathVariable final int id){
         
         //Buscar o paciente correspondente ao id
 
         //Adicionar esse objeto no ModelAndView
 
+        ModelAndView mv = new ModelAndView("paciente-perfil");
+        mv.addObject("paciente", service.getPacienteByID(id));
+        return mv;
+
         //Exibir a tela de perfil        
-        return new ModelAndView("paciente-perfil");
+        // return new ModelAndView("paciente-perfil");
     }
 
     //Exibir as CONSULTAS FUTURAS do paciente

--- a/clincode/src/main/java/com/api/clincode/controller/PacienteController.java
+++ b/clincode/src/main/java/com/api/clincode/controller/PacienteController.java
@@ -27,12 +27,12 @@ public class PacienteController {
     private PacienteService service;
 
     @GetMapping()
-    public List<PacienteEntity> getAllPacientes(){
+    public List<PacienteEntity> getAllPacientes() {
         return service.getAllPacientes();
     }
     
     @GetMapping("/{id}")
-    public ResponseEntity<PacienteEntity> getPacienteByID(@PathVariable final int id){
+    public ResponseEntity<PacienteEntity> getPacienteByID(@PathVariable final int id) {
         PacienteEntity paciente;
         paciente = service.getPacienteByID(id);
 
@@ -43,7 +43,7 @@ public class PacienteController {
     }
 
     @PostMapping()
-    public ResponseEntity<Void> postPaciente(@ModelAttribute PacienteEntity entity){
+    public ResponseEntity<Void> postPaciente(@ModelAttribute PacienteEntity entity) {
         entity = service.salvarPaciente(entity);
 
         if(entity != null)
@@ -56,7 +56,7 @@ public class PacienteController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<PacienteEntity> putPacienteByID(@PathVariable int id, @RequestBody PacienteEntity paciente){
+    public ResponseEntity<PacienteEntity> putPacienteByID(@PathVariable int id, @RequestBody PacienteEntity paciente) {
        
         paciente = service.putPacienteByID(id, paciente);
 
@@ -68,7 +68,7 @@ public class PacienteController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePacienteByID(@PathVariable int id){
+    public ResponseEntity<Void> deletePacienteByID(@PathVariable int id) {
         Boolean val = service.existePacienteByID(id);
 
         if(val == true){
@@ -80,23 +80,17 @@ public class PacienteController {
 
     //Pagina de perfil de cada paciente
     @GetMapping("{id}/perfil")
-    public ModelAndView pacientePerfil(@PathVariable final int id){
-        
-        //Buscar o paciente correspondente ao id
-
-        //Adicionar esse objeto no ModelAndView
-
+    public ModelAndView pacientePerfil(@PathVariable final int id) {
         ModelAndView mv = new ModelAndView("paciente-perfil");
-        mv.addObject("paciente", service.getPacienteByID(id));
-        return mv;
 
-        //Exibir a tela de perfil        
-        // return new ModelAndView("paciente-perfil");
+        mv.addObject("paciente", service.getPacienteByID(id));
+
+        return mv;
     }
 
     //Exibir as CONSULTAS FUTURAS do paciente
     @GetMapping("{id}/consultas/agendadas")
-    public ModelAndView pacienteIndex(){
+    public ModelAndView pacienteConsultasAgendadas() {
 
         //Buscar o paciente referente ao id
 
@@ -110,7 +104,7 @@ public class PacienteController {
 
     //Exibir as consultas JA REALIZADAS do paciente
     @GetMapping("{id}/consultas/historico")
-    public ModelAndView historicoConsultas(){
+    public ModelAndView historicoConsultasHistorico() {
         
         //Buscar o paciente referente ao id
 

--- a/clincode/src/main/java/com/api/clincode/entity/AgendamentoEntity.java
+++ b/clincode/src/main/java/com/api/clincode/entity/AgendamentoEntity.java
@@ -4,10 +4,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class AgendamentoEntity {
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int idAgendamento;
@@ -19,8 +20,19 @@ public class AgendamentoEntity {
     private String data;
     private String horario;
 
+    @ManyToOne
+    private PacienteEntity paciente;
+
     public int getIdAgendamento() {
         return idAgendamento;
+    }
+
+    public PacienteEntity getPaciente() {
+        return paciente;
+    }
+
+    public void setPaciente(PacienteEntity paciente) {
+        this.paciente = paciente;
     }
 
     public void setIdAgendamento(int idAgendamento) {
@@ -74,7 +86,5 @@ public class AgendamentoEntity {
     public void setHorario(String horario) {
         this.horario = horario;
     }
-
-    
 
 }

--- a/clincode/src/main/java/com/api/clincode/entity/AgendamentoEntity.java
+++ b/clincode/src/main/java/com/api/clincode/entity/AgendamentoEntity.java
@@ -4,6 +4,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 @Entity
@@ -21,6 +22,7 @@ public class AgendamentoEntity {
     private String horario;
 
     @ManyToOne
+    @JoinColumn(name="ID_PACIENTE")
     private PacienteEntity paciente;
 
     public int getIdAgendamento() {

--- a/clincode/src/main/java/com/api/clincode/entity/MedicoEntity.java
+++ b/clincode/src/main/java/com/api/clincode/entity/MedicoEntity.java
@@ -7,9 +7,6 @@ import javax.persistence.PrimaryKeyJoinColumn;
 @PrimaryKeyJoinColumn(name="idPessoa")
 public class MedicoEntity extends PessoaEntity{
 
-    /**
-	 *
-	 */
 	private static final long serialVersionUID = 1L;
 	private String crm;
 	private String turno;

--- a/clincode/src/main/java/com/api/clincode/entity/PacienteEntity.java
+++ b/clincode/src/main/java/com/api/clincode/entity/PacienteEntity.java
@@ -1,26 +1,37 @@
 package com.api.clincode.entity;
 
+import java.util.List;
 
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
 import javax.persistence.PrimaryKeyJoinColumn;
 
-
 @Entity
-@PrimaryKeyJoinColumn(name="idPessoa")
-public class PacienteEntity extends PessoaEntity{
+@PrimaryKeyJoinColumn(name = "idPessoa")
+public class PacienteEntity extends PessoaEntity {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
-    private String  tipoSanguineo;
-    private String  convenio;
-    private int     numeroCarteirinha;
-    private String  vicios;
-    private String  doencas;
+    private String tipoSanguineo;
+    private String convenio;
+    private int numeroCarteirinha;
+    private String vicios;
+    private String doencas;
+
+    @OneToMany
+    @JoinColumn(name="ID_PACIENTE")
+    private List<AgendamentoEntity> agendamentos;
 
     public String getTipoSanguineo() {
         return tipoSanguineo;
+    }
+
+    public List<AgendamentoEntity> getAgendamentos() {
+        return agendamentos;
+    }
+
+    public void setAgendamentos(List<AgendamentoEntity> agendamentos) {
+        this.agendamentos = agendamentos;
     }
 
     public void setTipoSanguineo(String tipoSanguineo) {

--- a/clincode/src/main/java/com/api/clincode/service/AgendamentoService.java
+++ b/clincode/src/main/java/com/api/clincode/service/AgendamentoService.java
@@ -21,17 +21,17 @@ public class AgendamentoService {
         return repository.findAll();
     }
 
-	public AgendamentoEntity getAgendamentoByID(int id) {
+    public AgendamentoEntity getAgendamentoByID(int id) {
         Optional<AgendamentoEntity> op = repository.findById(id);
         
         return op.orElseThrow( () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Agendamento sem registros"));
-	}
+    }
 
-	public AgendamentoEntity cadastraConsulta(AgendamentoEntity entity) {
-		return repository.save(entity);
-	}
+    public AgendamentoEntity cadastraConsulta(AgendamentoEntity entity) {
+	    return repository.save(entity);
+    }
 
-	public AgendamentoEntity alteraInformacoesByEntidade(AgendamentoEntity destinoEntity, AgendamentoEntity modificacoesEntity) {
+    public AgendamentoEntity alteraInformacoesByEntidade(AgendamentoEntity destinoEntity, AgendamentoEntity modificacoesEntity) {
         destinoEntity.setNome(modificacoesEntity.getNome());
         destinoEntity.setTelefone(modificacoesEntity.getTelefone());
         destinoEntity.setEmail(modificacoesEntity.getEmail());
@@ -42,14 +42,14 @@ public class AgendamentoService {
         destinoEntity = repository.save(destinoEntity);
 
         return destinoEntity;
-	}
+    }
 
-	public boolean deleteAgendamentoByID(int id) {
+    public boolean deleteAgendamentoByID(int id) {
         AgendamentoEntity entity = getAgendamentoByID(id);
-        
+                
         repository.delete(entity);
 
         return true;
-	}
+    }
 
 }

--- a/clincode/src/main/resources/application.properties
+++ b/clincode/src/main/resources/application.properties
@@ -5,3 +5,5 @@ spring.datasource.url=jdbc:derby:bdclincode;create=true
 spring.jpa.hibernate.ddl-auto=update
 
 server.error.include-stacktrace=never
+server.error.whitelabel.enabled=false
+server.error.path=/error

--- a/clincode/src/main/resources/static/styles/pacientes.css
+++ b/clincode/src/main/resources/static/styles/pacientes.css
@@ -29,6 +29,27 @@
     margin-left: 15px;
 }
 
+/* .nomePerfil{
+    width: 500px;
+    text-align: center;
+    box-shadow: 0;
+    border: 0 none;
+    margin-left: 5px;
+    background: #ffffff;
+    color: black;
+    font-weight: bolder;
+}
+
+.rgCpfPerfil{
+    width: 100px;
+    text-align: center;
+    box-shadow: 0;
+    border: 0 none;
+    background: #ffffff;
+    color: black;
+    font-weight: bolder;
+} */
+
 @media(max-width: 768px){
     .content{
         padding: 50px 5%;

--- a/clincode/src/main/resources/templates/atendente-perfil.html
+++ b/clincode/src/main/resources/templates/atendente-perfil.html
@@ -28,68 +28,71 @@
                 <div class="avatar"></div>
                 <div class="info">
                     <div class="nome">
-                        <h2>Vitor Joaquim de Carvalho Gois</h2>
+                        <h2 th:text="${atendente.nome}"></h2>
                     </div>
                     <div class="documentos">
-                        <b>RG: 12.123.123-1</b>
-                        <b>CPF: 123.123.123-01</b>
+                        <label for="rg"><strong>RG:</strong></label>
+                        <b th:text="${atendente.rg}"></b>
+                        &emsp;
+                        <label for="cpf"><strong>CPF:</strong></label>
+                        <b th:text="${atendente.cpf}"></b>
                     </div>
                 </div>
                 
             </div>
 
-            <form th:action="@{/atendentes}" method="POST">
+            <form th:action="@{/atendentes}" method="PUT">
                 <div class="form-style">
                     <div class="form-row">
                         <div class="form-group col-md-4">
                             <label for="dataNascimento">Data de Nascimento: </label>
-                            <input type="date" class="form-control" id="dataNascimento" value="2001-01-30" name="dataNascimento" required>
+                            <input type="date" class="form-control" id="dataNascimento" th:value="${atendente.dataNascimento}" name="dataNascimento" disabled>
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone1">Telefone 1: </label>
-                            <input type="text" class="form-control" id="telefone1" placeholder="(XX) 9 1234-1234" value="(XX) 9 1234-1234" name="telefone1" required>
+                            <input type="text" class="form-control" id="telefone1" placeholder="-" th:value="${atendente.telefone1}" name="telefone1" required>
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone2">Telefone 2: </label>
-                            <input type="text" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" value="(XX) 9 1234-1234" name="telefone2" required> 
+                            <input type="text" class="form-control" id="telefone2" placeholder="-" th:value="${atendente.telefone2}" name="telefone2" required> 
                         </div>
                     </div>
                     <div class="form-group">
                         <label for="email">Email:</label>
-                        <input type="email" class="form-control" id="email" placeholder="123@facens.br" value="vitor@facens.br" name="email" required>
+                        <input type="email" class="form-control" id="email" placeholder="-" th:value="${atendente.email}" name="email" required>
                     </div>  
                     <div class="form-row">
                         <div class="form-group col-md-8">
                             <label for="rua">Endereço:</label>
-                            <input type="text" class="form-control" id="rua" placeholder="R. Facens, 123" value="R. Facens, 123" name="rua" required>
+                            <input type="text" class="form-control" id="rua" placeholder="-" th:value="${atendente.rua}" name="rua" required>
                         </div>
                         <div class="form-group col-md-4">
                             <label for="bairro">Bairro: </label>
-                            <input type="text" class="form-control" id="bairro" placeholder="Jardim" value="Jardim" name="bairro" required>
+                            <input type="text" class="form-control" id="bairro" placeholder="-" th:value="${atendente.bairro}" name="bairro" required>
                         </div>
                     </div>    
                     <div class="form-row">
                         <div class="form-group col-md-6">
                         <label for="cidade">Cidade:</label>
-                        <input type="text" class="form-control" id="cidade" placeholder="Sorocaba" value="Sorocaba" name="cidade" required>
+                        <input type="text" class="form-control" id="cidade" placeholder="-" th:value="${atendente.cidade}" name="cidade" required>
                         </div>
                         <div class="form-group col-md-4">
                         <label for="estado">Estado:</label>
-                        <input type="text" class="form-control" id="estado" placeholder="SP" value="SP" name="estado" required>
+                        <input type="text" class="form-control" id="estado" placeholder="-" th:value="${atendente.estado}"name="estado" required>
                         </div>
                         <div class="form-group col-md-2">
                         <label for="numeroCasa">Numero da casa:</label>
-                        <input type="num" class="form-control" id="numeroCasa" placeholder="999" value="111" name="numeroCasa" required>
+                        <input type="num" class="form-control" id="numeroCasa" placeholder="-" th:value="${atendente.numeroCasa}" name="numeroCasa" required>
                         </div>
                     </div>
                     <div class="form-row">
                         <div class="form-group col-md-6">
                         <label for="crm">Área:</label>
-                        <input type="num" class="form-control" id="area" placeholder="Recepção" value="Recepção" name="area" disabled required>
+                        <input type="num" class="form-control" id="area" placeholder="-" th:value="${atendente.area}" name="area" disabled>
                         </div>
                         <div class="form-group col-md-6">
                             <label for="turno">Turno:</label>
-                            <input type="text" class="form-control" id="turno" placeholder="Noturno" name="turno" disabled required>
+                            <input type="text" class="form-control" id="turno"placeholder="-" th:value="${atendente.turno}" name="turno" disabled>
                             </div>
                     </div>                                         
                 </div>

--- a/clincode/src/main/resources/templates/cad-atendentes.html
+++ b/clincode/src/main/resources/templates/cad-atendentes.html
@@ -50,7 +50,7 @@
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone2">Telefone 2: </label>
-                            <input type="text" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" name="telefone2" required> 
+                            <input type="text" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" name="telefone2"> 
                         </div>
                     </div>
                     <div class="form-row">

--- a/clincode/src/main/resources/templates/cad-medico.html
+++ b/clincode/src/main/resources/templates/cad-medico.html
@@ -50,7 +50,7 @@
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone2">Telefone 2: </label>
-                            <input type="number" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" name="telefone2" required> 
+                            <input type="number" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" name="telefone2"> 
                         </div>
                     </div>
                     <div class="form-row">

--- a/clincode/src/main/resources/templates/cad-pacientes.html
+++ b/clincode/src/main/resources/templates/cad-pacientes.html
@@ -51,7 +51,7 @@
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone2">Telefone 2: </label>
-                            <input type="text" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" name="telefone2" required> 
+                            <input type="text" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" name="telefone2"> 
                         </div>
                     </div>
                     <div class="form-row">

--- a/clincode/src/main/resources/templates/error-404.html
+++ b/clincode/src/main/resources/templates/error-404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" rel="stylesheet" id="bootstrap-css">
+
+    <style>
+        body {
+            background: #dedede;
+        }
+
+        .page-wrap {
+            min-height: 100vh;
+        }
+    </style>
+
+    <title>Oh no!</title>
+</head>
+
+<body>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <!------ Include the above in your HEAD tag ---------->
+
+    <div class="page-wrap d-flex flex-row align-items-center">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-md-12 text-center">
+                    <span class="display-1 d-block">404</span>
+                    <div class="mb-4 lead">The page you are looking for was not found.</div>
+                    <a href="/" class="btn btn-link">Back to Home</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</body>
+
+</html>

--- a/clincode/src/main/resources/templates/medico-perfil.html
+++ b/clincode/src/main/resources/templates/medico-perfil.html
@@ -28,11 +28,14 @@
                 <div class="avatar"></div>
                 <div class="info">
                     <div class="nome">
-                        <h2>Doutor Gabriel José Ferraz Perin</h2>
+                        <h2 th:text="${medico.nome}"></h2>
                     </div>
                     <div class="documentos">
-                        <b>RG: 12.123.123-1</b>
-                        <b>CPF: 123.123.123-01</b>
+                        <label for="rg"><strong>RG:</strong></label>
+                        <b th:text="${medico.rg}"></b>
+                        &emsp;
+                        <label for="cpf"><strong>CPF:</strong></label>
+                        <b th:text="${medico.cpf}"></b>
                     </div>
                 </div>
                 
@@ -43,63 +46,68 @@
                     <div class="form-row">
                         <div class="form-group col-md-4">
                             <label for="dataNascimento">Data de Nascimento: </label>
-                            <input type="date" class="form-control" id="dataNascimento" value="2001-01-30" name="dataNascimento" required>
+                            <input type="date" class="form-control" id="dataNascimento" th:value="${medico.dataNascimento}" name="dataNascimento" disabled>
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone1">Telefone 1: </label>
-                            <input type="text" class="form-control" id="telefone1" placeholder="(XX) 9 1234-1234" value="(XX) 9 1234-1234" name="telefone1" required>
+                            <input type="text" class="form-control" id="telefone1" placeholder="-" th:value="${medico.telefone1}" name="telefone1" required>
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone2">Telefone 2: </label>
-                            <input type="text" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" value="(XX) 9 1234-1234" name="telefone2" required> 
+                            <input type="text" class="form-control" id="telefone2" placeholder="-" th:value="${medico.telefone2}" name="telefone2" required> 
                         </div>
                     </div>
                     <div class="form-group">
                         <label for="email">Email:</label>
-                        <input type="email" class="form-control" id="email" placeholder="123@facens.br" value="gabriel@facens.br" name="email" required>
+                        <input type="email" class="form-control" id="email" placeholder="-" th:value="${medico.email}" name="email" required>
                     </div>  
                     <div class="form-row">
                         <div class="form-group col-md-8">
                             <label for="rua">Endereço:</label>
-                            <input type="text" class="form-control" id="rua" placeholder="R. Facens, 123" value="R. Aurora Redini, 123" name="rua" required>
+                            <input type="text" class="form-control" id="rua" placeholder="-" th:value="${medico.rua}" name="rua" required>
                         </div>
                         <div class="form-group col-md-4">
                             <label for="bairro">Bairro: </label>
-                            <input type="text" class="form-control" id="bairro" placeholder="Jardim" value="Jardim" name="bairro" required>
+                            <input type="text" class="form-control" id="bairro" placeholder="-" th:value="${medico.bairro}" name="bairro" required>
                         </div>
                     </div>    
                     <div class="form-row">
                         <div class="form-group col-md-6">
                         <label for="cidade">Cidade:</label>
-                        <input type="text" class="form-control" id="cidade" placeholder="Sorocaba" value="Sorocaba" name="cidade" required>
+                        <input type="text" class="form-control" id="cidade" placeholder="-" th:value="${medico.cidade}" name="cidade" required>
                         </div>
                         <div class="form-group col-md-4">
                         <label for="estado">Estado:</label>
-                        <input type="text" class="form-control" id="estado" placeholder="SP" value="SP" name="estado" required>
+                        <input type="text" class="form-control" id="estado" placeholder="-" th:value="${medico.estado}"name="estado" required>
                         </div>
                         <div class="form-group col-md-2">
                         <label for="numeroCasa">Numero da casa:</label>
-                        <input type="num" class="form-control" id="numeroCasa" placeholder="999" value="111" name="numeroCasa" required>
+                        <input type="num" class="form-control" id="numeroCasa" placeholder="-" th:value="${medico.numeroCasa}" name="numeroCasa" required>
                         </div>
                     </div>
                     <div class="form-row">
                         <div class="form-group col-md-6">
                         <label for="crm">CRM:</label>
-                        <input type="num" class="form-control" id="crm" placeholder="123456" value="1010" name="crm" disabled required>
+                        <input type="num" class="form-control" id="crm" placeholder="-" th:value="${medico.crm}" name="crm" disabled>
                         </div>
                         <div class="form-group col-md-6">
                             <label for="turno">Turno:</label>
-                            <input type="text" class="form-control" id="turno" placeholder="Noturno" name="turno" disabled required>
+                            <input type="text" class="form-control" id="turno" placeholder="-" th:value="${medico.turno}" name="turno" disabled>
                             </div>
                     </div>                    
                     <div class="form-group">
-                        <label for="especialidade-1">Especialidade 1:</label>
-                        <input type="text" class="form-control" id="esp1" placeholder="Clinico Geral" value="" name="esp1">
+                        <label for="esp1">Especialidade 1:</label>
+                        <input type="text" class="form-control" id="esp1" placeholder="-" th:value="${medico.especialidade1}" name="esp1" disabled>
                     </div>
                     <div class="form-group">
-                        <label for="especialidade-2">Especialidade 2:</label>
-                        <input type="text" class="form-control" id="esp2" placeholder="Oftalmologista" value="" name="esp1">
+                        <label for="esp2">Especialidade 2:</label>
+                        <input type="text" class="form-control" id="esp2" placeholder="-" th:value="${medico.especialidade2}" name="esp2" disabled>
                     </div>                      
+                </div>
+                <hr style="border-color: rgb(64 117 255);">
+                <div class="btn-form">
+                    <button type="submit" class="btn btn-clin" style="margin-left: 10px;" value="">Cadastrar</button>
+                    <button type="submit" class="btn btn-outline-secondary">Limpar</button>
                 </div>
             </form>
         </div>

--- a/clincode/src/main/resources/templates/paciente-perfil.html
+++ b/clincode/src/main/resources/templates/paciente-perfil.html
@@ -30,82 +30,93 @@
                 <div class="avatar"></div>
                 <div class="info">
                     <div class="nome">
-                        <h2>Raul Ryan Deaque Silva</h2>
+                        <!-- <h2><input type="text" class="nomePerfil" id="nome" th:value="${paciente.nome}" name="nome" disabled></h2> -->
+                        <h2 th:text="${paciente.nome}"></h2>
                     </div>
                     <div class="documentos">
-                        <b>RG: 12.123.123-1</b>
-                        <b>CPF: 123.123.123-01</b>
+                        <label for="rg"><strong>RG:</strong></label>
+                        <b th:text="${paciente.rg}"></b>
+                        &emsp;
+                        <!-- <b><input type="text" class="rgCpfPerfil" id="rg" th:value="${paciente.rg}" name="rg" disabled></b> -->
+                        <label for="cpf"><strong>CPF:</strong></label>
+                        <b th:text="${paciente.cpf}"></b>
+                        <!-- <b><input type="text" class="rgCpfPerfil" id="cpf" th:value="${paciente.cpf}" name="cpf" disabled></b> -->
                     </div>
                 </div>
                 
             </div>
 
-            <form th:action="@{/pacientes}" method="POST">
+            <form th:action="@{/pacientes}" method="PUT">
                 <div class="form-style">
                     <div class="form-row">
                         <div class="form-group col-md-4">
                             <label for="dataNascimento">Data de Nascimento: </label>
-                            <input type="date" class="form-control" id="dataNascimento" value="2001-01-30" name="dataNascimento" required>
+                            <input type="date" class="form-control" id="dataNascimento" th:value="${paciente.dataNascimento}" name="dataNascimento" disabled>
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone1">Telefone 1: </label>
-                            <input type="text" class="form-control" id="telefone1" placeholder="(XX) 9 1234-1234" value="(XX) 9 1234-1234" name="telefone1" required>
+                            <input type="text" class="form-control" id="telefone1" placeholder="-" th:value="${paciente.telefone1}" name="telefone1">
                         </div>
                         <div class="form-group col-md-4">
                             <label for="telefone2">Telefone 2: </label>
-                            <input type="text" class="form-control" id="telefone2" placeholder="(XX) 9 1234-1234" value="(XX) 9 1234-1234" name="telefone2" required> 
+                            <input type="text" class="form-control" id="telefone2" placeholder="-" th:value="${paciente.telefone2}" name="telefone2"> 
                         </div>
                     </div>
                     <div class="form-group">
                         <label for="email">Email:</label>
-                        <input type="email" class="form-control" id="email" placeholder="123@facens.br" value="raul@facens.br" name="email" required>
+                        <input type="email" class="form-control" id="email" placeholder="-" th:value="${paciente.email}" name="email">
                     </div>  
                     <div class="form-row">
                         <div class="form-group col-md-8">
                             <label for="rua">Endereço:</label>
-                            <input type="text" class="form-control" id="rua" placeholder="R. Facens, 123" value="R. Aurora Redini, 123" name="rua" required>
+                            <input type="text" class="form-control" id="rua" placeholder="-" th:value="${paciente.rua}" name="rua">
                         </div>
                         <div class="form-group col-md-4">
                             <label for="bairro">Bairro: </label>
-                            <input type="text" class="form-control" id="bairro" placeholder="Jardim" value="Jardim" name="bairro" required>
+                            <input type="text" class="form-control" id="bairro" placeholder="-" th:value="${paciente.bairro}" name="bairro">
                         </div>
                     </div>    
                     <div class="form-row">
                         <div class="form-group col-md-6">
                         <label for="cidade">Cidade:</label>
-                        <input type="text" class="form-control" id="cidade" placeholder="Sorocaba" value="Sorocaba" name="cidade" required>
+                        <input type="text" class="form-control" id="cidade" placeholder="-" th:value="${paciente.cidade}" name="cidade">
                         </div>
                         <div class="form-group col-md-4">
                         <label for="estado">Estado:</label>
-                        <input type="text" class="form-control" id="estado" placeholder="SP" value="SP" name="estado" required>
+                        <input type="text" class="form-control" id="estado" placeholder="-" th:value="${paciente.estado}" name="estado">
                         </div>
                         <div class="form-group col-md-2">
                         <label for="numeroCasa">Numero da casa:</label>
-                        <input type="num" class="form-control" id="numeroCasa" placeholder="999" value="111" name="numeroCasa" required>
+                        <input type="num" class="form-control" id="numeroCasa" placeholder="-" th:value="${paciente.numeroCasa}" name="numeroCasa">
                         </div>
                     </div>
                     <div class="form-row">
                         <div class="form-group col-md-6">
                         <label for="convenio">Convenio:</label>
-                        <input type="text" class="form-control" id="convenio" placeholder="Santa Casa" value="Santa Casa" name="convenio" disabled required>
+                        <input type="text" class="form-control" id="convenio" placeholder="-" th:value="${paciente.convenio}" name="convenio" disabled>
                         </div>
                         <div class="form-group col-md-4">
                         <label for="numeroCarteirinha">Numero da Carteirinha:</label>
-                        <input type="num" class="form-control" id="numeroCarteirinha" placeholder="123456" value="123456" name="numeroCarteirinha" disabled required>
+                        <input type="num" class="form-control" id="numeroCarteirinha" placeholder="-" th:value="${paciente.numeroCarteirinha}" name="numeroCarteirinha" disabled>
                         </div>
                         <div class="form-group col-md-2">
                         <label for="tipoSanguineo">Tipo sanguíneo:</label>
-                        <input type="text" class="form-control" id="tipoSanguineo" placeholder="A+" value="A+" name="tipoSanguineo" disabled required>
+                        <input type="text" class="form-control" id="tipoSanguineo" placeholder="-" th:value="${paciente.tipoSanguineo}" name="tipoSanguineo" disabled>
                         </div>
                     </div>                    
                     <div class="form-group">
                         <label for="doencas">Doenças:</label>
-                        <input type="text" class="form-control" id="doencas" placeholder="Descreva aqui todas suas doenças (caso tenha)" value="Sinusite" name="doencas">
+                        <input type="text" class="form-control" id="doencas" placeholder="-" th:value="${paciente.doencas}" name="doencas" disabled>
                     </div>
                     <div class="form-group">
                         <label for="vicios">Vicios:</label>
-                        <input type="text" class="form-control" id="vicios" placeholder="Descreva aqui todos os seus vícios (caso tenha)" value="-" name="vicios">
+                        <input type="text" class="form-control" id="vicios" placeholder="-" th:value="${paciente.vicios}" name="vicios" disabled>
                     </div>                      
+                </div>
+                <hr style="border-color: rgb(64 117 255);">
+                <div class="btn-form">
+                    <button type="submit" class="btn btn-clin" style="margin-left: 10px;" value="">Cadastrar</button>
+                    <button type="submit" class="btn btn-outline-secondary">Limpar</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
**Houve alteração nas seguintes páginas HTML:**
> Possibilitando uma maior dinamicidade com os dados cadastrados de cada usuário, possibilitando que apenas alguns campos seja possível realizar alterações. 
- [ x ] paciente-perfil
- [ x ] medico-perfil
- [ x ] atendente-perfil

**Tentativa falha de criar um relacionamento**
Para que fosse mostrado uma página com os todas as consultas agendadas para um determinado paciente, é necessário criar um relacionamento entre o agendamento e o paciente para que fosse exibido corretamente os mesmos, sendo assim, houve a tentativa de criar esse relacionamento incialmente nas Entity (Banco de Dados) de Paciente e Agendamento,
`@ManyToOne
 @JoinColumn(name="ID_PACIENTE")
 private PacienteEntity paciente;`
`@OneToMany
 @JoinColumn(name="ID_PACIENTE")
 private List<AgendamentoEntity> agendamentos;`
porém não foi possível de encontrar uma maneira de enviar o paciente para a linha da tabela de agendamento e nem de passar o agendamento para a linha da tabela de paciente.

**Extra**
Criação de uma página para ERRO 404, para teste:
[localhost:8080/algumacoisa](url)